### PR TITLE
Add worldboss event skeleton

### DIFF
--- a/server/dbschema/WorldbossAttack.php
+++ b/server/dbschema/WorldbossAttack.php
@@ -1,0 +1,24 @@
+<?php
+namespace Schema;
+
+use Srv\Record;
+use JsonSerializable;
+
+class WorldbossAttack extends Record implements JsonSerializable{
+    protected static $_TABLE = 'worldboss_attack';
+
+    public function jsonSerialize(){
+        return $this->getData();
+    }
+
+    protected static $_FIELDS = [
+        'id' => 0,
+        'worldboss_event_id' => 0,
+        'character_id' => 0,
+        'battle_id' => 0,
+        'damage' => 0,
+        'ts_start' => 0,
+        'ts_complete' => 0,
+        'status' => 1
+    ];
+}

--- a/server/dbschema/WorldbossEvent.php
+++ b/server/dbschema/WorldbossEvent.php
@@ -1,0 +1,29 @@
+<?php
+namespace Schema;
+
+use Srv\Record;
+use JsonSerializable;
+
+class WorldbossEvent extends Record implements JsonSerializable{
+    protected static $_TABLE = 'worldboss_event';
+
+    public function jsonSerialize(){
+        return $this->getData();
+    }
+
+    protected static $_FIELDS = [
+        'id' => 0,
+        'identifier' => '',
+        'npc_identifier' => '',
+        'status' => 0,
+        'ts_start' => 0,
+        'ts_end' => 0,
+        'npc_hitpoints_total' => 0,
+        'npc_hitpoints_current' => 0,
+        'attack_count' => 0,
+        'top_attacker_character_id' => 0,
+        'top_attacker_count' => 0,
+        'top_attacker_name' => '',
+        'winning_attacker_name' => ''
+    ];
+}

--- a/server/request/assignWorldbossEvent.req.php
+++ b/server/request/assignWorldbossEvent.req.php
@@ -1,0 +1,21 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossEvent;
+
+class assignWorldbossEvent{
+    public function __request($player){
+        $event_id = intval(getField('worldboss_event_id', FIELD_NUM));
+        $event = WorldbossEvent::find(function($q) use ($event_id){
+            $q->where('id',$event_id);
+        });
+        if(!$event)
+            return Core::setError('errWorldbossInvalidEvent');
+        $player->character->worldboss_event_id = $event->id;
+        Core::req()->data = [
+            'character'=>$player->character,
+            'worldboss_event'=>$event
+        ];
+    }
+}

--- a/server/request/finishWorldbossAttack.req.php
+++ b/server/request/finishWorldbossAttack.req.php
@@ -1,0 +1,38 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossAttack;
+use Schema\WorldbossEvent;
+
+class finishWorldbossAttack{
+    public function __request($player){
+        $attack = WorldbossAttack::find(function($q) use ($player){
+            $q->where('id',$player->character->active_worldboss_attack_id);
+        });
+        if(!$attack)
+            return Core::setError('errNoActiveWorldbossAttack');
+
+        $damage = intval(getField('damage', FIELD_NUM));
+        $attack->damage = $damage;
+        $attack->ts_complete = time();
+        $attack->status = 2;
+
+        $event = WorldbossEvent::find(function($q) use ($attack){
+            $q->where('id',$attack->worldboss_event_id);
+        });
+        if($event){
+            $event->npc_hitpoints_current = max(0,$event->npc_hitpoints_current - $damage);
+            $event->attack_count += 1;
+        }
+
+        $player->character->active_worldboss_attack_id = 0;
+        $player->character->worldboss_event_attack_count += 1;
+
+        Core::req()->data = [
+            'character'=>$player->character,
+            'worldboss_attack'=>$attack,
+            'worldboss_event'=>$event
+        ];
+    }
+}

--- a/server/request/loginUser.req.php
+++ b/server/request/loginUser.req.php
@@ -30,6 +30,14 @@ class loginUser{
         $player->user->login_count++;
         
         $dailyLogin = $player->getDailyBonuses();
+        $eventData = [];
+        if($player->character->worldboss_event_id){
+            $event = \Schema\WorldbossEvent::find(function($q) use ($player){
+                $q->where('id',$player->character->worldboss_event_id);
+            });
+            if($event)
+                $eventData = $event;
+        }
 
         Core::req()->data = array(
             "user"=>$player->user,
@@ -68,7 +76,7 @@ class loginUser{
 			"ad_provider_keys"=>array(),
             "tournament_end_timestamp"=>0,
             "user_geo_location"=>"xX",
-            "worldboss_event_character_data"=>array()
+            "worldboss_event_character_data"=>$eventData
         );
         if($player->guild != null){
         	Core::req()->data['guild']= $player->guild;

--- a/server/request/startWorldbossAttack.req.php
+++ b/server/request/startWorldbossAttack.req.php
@@ -1,0 +1,35 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossEvent;
+use Schema\WorldbossAttack;
+
+class startWorldbossAttack{
+    public function __request($player){
+        if($player->character->active_worldboss_attack_id)
+            return Core::setError('errWorldbossAttackActive');
+        if(!$player->character->worldboss_event_id)
+            return Core::setError('errNoWorldbossEvent');
+
+        $event = WorldbossEvent::find(function($q) use ($player){
+            $q->where('id',$player->character->worldboss_event_id);
+        });
+        if(!$event || $event->status != 1)
+            return Core::setError('errWorldbossInvalidEvent');
+
+        $attack = new WorldbossAttack([
+            'worldboss_event_id'=>$event->id,
+            'character_id'=>$player->character->id,
+            'ts_start'=>time(),
+            'status'=>1
+        ]);
+        $attack->save();
+        $player->character->active_worldboss_attack_id = $attack->id;
+
+        Core::req()->data = [
+            'character'=>$player->character,
+            'worldboss_attack'=>$attack
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add new database schemas `WorldbossEvent` and `WorldbossAttack`
- implement requests to assign and attack worldboss events
- include event information during login

## Testing
- `php -l server/dbschema/WorldbossEvent.php`
- `php -l server/dbschema/WorldbossAttack.php`
- `php -l server/request/assignWorldbossEvent.req.php`
- `php -l server/request/startWorldbossAttack.req.php`
- `php -l server/request/finishWorldbossAttack.req.php`
- `php -l server/request/loginUser.req.php`


------
https://chatgpt.com/codex/tasks/task_e_68409039656883299917b02da7e68b53