### PR TITLE
Add worldboss tables

### DIFF
--- a/DATABASE.sql
+++ b/DATABASE.sql
@@ -996,6 +996,45 @@ CREATE TABLE `work` (
   `rewards` mediumtext NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
+-- --------------------------------------------------------
+
+--
+-- Struktura tabeli dla tabeli `worldboss_event`
+--
+
+CREATE TABLE `worldboss_event` (
+  `id` int(11) NOT NULL,
+  `identifier` varchar(64) NOT NULL,
+  `npc_identifier` varchar(64) NOT NULL,
+  `status` int(11) NOT NULL,
+  `ts_start` int(11) NOT NULL,
+  `ts_end` int(11) NOT NULL,
+  `npc_hitpoints_total` int(11) NOT NULL,
+  `npc_hitpoints_current` int(11) NOT NULL,
+  `attack_count` int(11) NOT NULL,
+  `top_attacker_character_id` int(11) NOT NULL,
+  `top_attacker_count` int(11) NOT NULL,
+  `top_attacker_name` varchar(64) NOT NULL,
+  `winning_attacker_name` varchar(64) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktura tabeli dla tabeli `worldboss_attack`
+--
+
+CREATE TABLE `worldboss_attack` (
+  `id` int(11) NOT NULL,
+  `worldboss_event_id` int(11) NOT NULL,
+  `character_id` int(11) NOT NULL,
+  `battle_id` int(11) NOT NULL,
+  `damage` int(11) NOT NULL,
+  `ts_start` int(11) NOT NULL,
+  `ts_complete` int(11) NOT NULL,
+  `status` tinyint(1) NOT NULL DEFAULT 1
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
 --
 -- Indeksy dla zrzutów tabel
 --
@@ -1215,6 +1254,21 @@ ALTER TABLE `work`
   ADD KEY `work` (`character_id`,`status`);
 
 --
+-- Indeksy dla tabeli `worldboss_attack`
+--
+ALTER TABLE `worldboss_attack`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `event` (`worldboss_event_id`,`status`),
+  ADD KEY `character_id` (`character_id`);
+
+--
+-- Indeksy dla tabeli `worldboss_event`
+--
+ALTER TABLE `worldboss_event`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `status` (`status`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -1396,6 +1450,18 @@ ALTER TABLE `user`
 -- AUTO_INCREMENT for table `work`
 --
 ALTER TABLE `work`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_attack`
+--
+ALTER TABLE `worldboss_attack`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_event`
+--
+ALTER TABLE `worldboss_event`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 COMMIT;
 

--- a/docs/WORLDBOSS_SCHEMA.md
+++ b/docs/WORLDBOSS_SCHEMA.md
@@ -1,0 +1,34 @@
+# Worldboss Schema
+
+Two new tables define world boss functionality. They must be created in the database before events or attacks can be stored.
+
+## `worldboss_event`
+| Column | Type | Description |
+| --- | --- | --- |
+| id | int(11) AUTO_INCREMENT | Primary key. |
+| identifier | varchar(64) | Unique id of the event. |
+| npc_identifier | varchar(64) | NPC template id used for the boss. |
+| status | int(11) | Current status value. |
+| ts_start | int(11) | Unix time when the event begins. |
+| ts_end | int(11) | Unix time when the event ends. |
+| npc_hitpoints_total | int(11) | Boss starting hitpoints. |
+| npc_hitpoints_current | int(11) | Remaining hitpoints. |
+| attack_count | int(11) | Total attacks made. |
+| top_attacker_character_id | int(11) | Character id of the top attacker. |
+| top_attacker_count | int(11) | Attack count for the top attacker. |
+| top_attacker_name | varchar(64) | Name of the top attacker. |
+| winning_attacker_name | varchar(64) | Name of the final attacker. |
+
+## `worldboss_attack`
+| Column | Type | Description |
+| --- | --- | --- |
+| id | int(11) AUTO_INCREMENT | Primary key. |
+| worldboss_event_id | int(11) | Event this attack belongs to. |
+| character_id | int(11) | Attacking character. |
+| battle_id | int(11) | Related battle record. |
+| damage | int(11) | Damage dealt. |
+| ts_start | int(11) | Attack start time. |
+| ts_complete | int(11) | Attack completion time. |
+| status | tinyint(1) | Attack status. |
+
+Both tables use InnoDB and have primary key indexes. Additional indexes are defined in `DATABASE.sql` to improve lookups by event id, character id and status.


### PR DESCRIPTION
## Summary
- define `worldboss_event` and `worldboss_attack` tables in `DATABASE.sql`
- create indexes and AUTO_INCREMENT sections for the new tables
- add documentation describing the new schema

## Testing
- `php -l server/dbschema/WorldbossEvent.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095315fb08329883fceb06811a056