### PR TITLE
Add worldboss example and status query

### DIFF
--- a/DATABASE.sql
+++ b/DATABASE.sql
@@ -996,6 +996,69 @@ CREATE TABLE `work` (
   `rewards` mediumtext NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
+-- --------------------------------------------------------
+--
+-- Struktura tabeli dla tabeli `worldboss_event`
+--
+
+CREATE TABLE `worldboss_event` (
+  `id` int(11) NOT NULL,
+  `identifier` varchar(32) NOT NULL,
+  `npc_identifier` varchar(32) NOT NULL,
+  `status` tinyint(4) NOT NULL DEFAULT 0,
+  `ts_start` int(11) NOT NULL,
+  `ts_end` int(11) NOT NULL,
+  `npc_hitpoints_total` int(11) NOT NULL,
+  `npc_hitpoints_current` int(11) NOT NULL,
+  `min_level` smallint(6) NOT NULL DEFAULT 1,
+  `max_level` smallint(6) NOT NULL DEFAULT 1,
+  `stage` tinyint(4) NOT NULL DEFAULT 1,
+  `attack_count` int(11) NOT NULL DEFAULT 0,
+  `top_attacker_character_id` int(11) NOT NULL DEFAULT 0,
+  `top_attacker_count` int(11) NOT NULL DEFAULT 0,
+  `top_attacker_name` varchar(64) NOT NULL,
+  `winning_attacker_name` varchar(64) NOT NULL,
+  `ranking` int(11) NOT NULL DEFAULT 0,
+  `coin_reward_total` int(11) NOT NULL DEFAULT 0,
+  `coin_reward_next_attack` int(11) NOT NULL DEFAULT 0,
+  `xp_reward_total` int(11) NOT NULL DEFAULT 0,
+  `xp_reward_next_attack` int(11) NOT NULL DEFAULT 0,
+  `reward_top_rank_item_identifier` varchar(64) NOT NULL,
+  `reward_top_pool_item_identifier` varchar(64) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Struktura tabeli dla tabeli `worldboss_attack`
+--
+
+CREATE TABLE `worldboss_attack` (
+  `id` int(11) NOT NULL,
+  `worldboss_event_id` int(11) NOT NULL,
+  `character_id` int(11) NOT NULL,
+  `battle_id` int(11) NOT NULL,
+  `damage` int(11) NOT NULL DEFAULT 0,
+  `ts_start` int(11) NOT NULL,
+  `ts_complete` int(11) NOT NULL,
+  `status` tinyint(1) NOT NULL DEFAULT 1
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Struktura tabeli dla tabeli `worldboss_reward`
+--
+
+CREATE TABLE `worldboss_reward` (
+  `id` int(11) NOT NULL,
+  `worldboss_event_id` int(11) NOT NULL,
+  `character_id` int(11) NOT NULL,
+  `game_currency` int(11) NOT NULL DEFAULT 0,
+  `xp` int(11) NOT NULL DEFAULT 0,
+  `item_id` int(11) NOT NULL DEFAULT 0,
+  `sidekick_item_id` int(11) NOT NULL DEFAULT 0,
+  `rewards` varchar(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
 --
 -- Indeksy dla zrzutów tabel
 --
@@ -1215,6 +1278,27 @@ ALTER TABLE `work`
   ADD KEY `work` (`character_id`,`status`);
 
 --
+-- Indeksy dla tabeli `worldboss_event`
+--
+ALTER TABLE `worldboss_event`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `status` (`status`);
+
+--
+-- Indeksy dla tabeli `worldboss_attack`
+--
+ALTER TABLE `worldboss_attack`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `event_character` (`worldboss_event_id`,`character_id`);
+
+--
+-- Indeksy dla tabeli `worldboss_reward`
+--
+ALTER TABLE `worldboss_reward`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `event_character` (`worldboss_event_id`,`character_id`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -1396,6 +1480,24 @@ ALTER TABLE `user`
 -- AUTO_INCREMENT for table `work`
 --
 ALTER TABLE `work`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_event`
+--
+ALTER TABLE `worldboss_event`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_attack`
+--
+ALTER TABLE `worldboss_attack`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `worldboss_reward`
+--
+ALTER TABLE `worldboss_reward`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 COMMIT;
 

--- a/DATABASE.sql
+++ b/DATABASE.sql
@@ -1056,7 +1056,8 @@ CREATE TABLE `worldboss_reward` (
   `xp` int(11) NOT NULL DEFAULT 0,
   `item_id` int(11) NOT NULL DEFAULT 0,
   `sidekick_item_id` int(11) NOT NULL DEFAULT 0,
-  `rewards` varchar(255) NOT NULL
+  `rewards` varchar(255) NOT NULL,
+  `claimed` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 --
@@ -1296,7 +1297,7 @@ ALTER TABLE `worldboss_attack`
 --
 ALTER TABLE `worldboss_reward`
   ADD PRIMARY KEY (`id`),
-  ADD KEY `event_character` (`worldboss_event_id`,`character_id`);
+  ADD UNIQUE KEY `event_character` (`worldboss_event_id`,`character_id`);
 
 --
 -- AUTO_INCREMENT for dumped tables

--- a/admin/worldboss.php
+++ b/admin/worldboss.php
@@ -1,0 +1,84 @@
+<?php
+// Simple admin interface to create and activate a worldboss event
+
+define('IN_ENGINE', true);
+define('BASE_DIR', dirname(__DIR__));
+define('SERVER_DIR', BASE_DIR.'/server');
+
+require_once(SERVER_DIR.'/src/Utils/functions.php');
+require_once(SERVER_DIR.'/src/Utils/field.php');
+require_once(SERVER_DIR.'/src/Utils/autoloader.php');
+
+\Srv\Config::__init();
+\Srv\DB::__init();
+
+$secretCfg = \Srv\Config::get('admin_secret');
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $secret = $_POST['secret'] ?? '';
+    if ($secret !== $secretCfg) {
+        $message = 'Invalid secret';
+    } else {
+        $identifier = trim($_POST['identifier'] ?? '');
+        $npc = trim($_POST['npc_identifier'] ?? '');
+        $start = strtotime($_POST['start'] ?? '');
+        $end = strtotime($_POST['end'] ?? '');
+        $hp = intval($_POST['hitpoints'] ?? 0);
+        $minLevel = intval($_POST['min_level'] ?? 1);
+        $maxLevel = intval($_POST['max_level'] ?? 1);
+        $stage = intval($_POST['stage'] ?? 1);
+
+        if (!$identifier || !$npc || !$start || !$end || $hp <= 0) {
+            $message = 'All fields are required';
+        } else {
+            $event = new \Schema\WorldbossEvent([
+                'identifier' => $identifier,
+                'npc_identifier' => $npc,
+                'status' => 1,
+                'ts_start' => $start,
+                'ts_end' => $end,
+                'npc_hitpoints_total' => $hp,
+                'npc_hitpoints_current' => $hp,
+                'min_level' => $minLevel,
+                'max_level' => $maxLevel,
+                'stage' => $stage
+            ]);
+            $event->save();
+
+            \Srv\DB::table('character')->update([
+                'worldboss_event_id' => $event->id,
+                'worldboss_event_attack_count' => 0,
+                'active_worldboss_attack_id' => 0
+            ])->execute();
+
+            $message = 'Worldboss event created with ID ' . $event->id;
+        }
+    }
+}
+?>
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Worldboss Admin</title>
+</head>
+<body>
+<h1>Worldboss Admin</h1>
+<?php if ($message): ?>
+<p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+    <label>Secret:<br><input type="password" name="secret"></label><br>
+    <label>Identifier:<br><input type="text" name="identifier"></label><br>
+    <label>NPC Identifier:<br><input type="text" name="npc_identifier"></label><br>
+    <label>Start (YYYY-MM-DD HH:MM:SS):<br><input type="text" name="start"></label><br>
+    <label>End (YYYY-MM-DD HH:MM:SS):<br><input type="text" name="end"></label><br>
+    <label>Total Hitpoints:<br><input type="number" name="hitpoints" min="1"></label><br>
+    <label>Min Level:<br><input type="number" name="min_level" min="1" value="1"></label><br>
+    <label>Max Level:<br><input type="number" name="max_level" min="1" value="1"></label><br>
+    <label>Stage:<br><input type="number" name="stage" min="1" value="1"></label><br>
+    <button type="submit">Create Event</button>
+</form>
+</body>
+</html>

--- a/docs/worldboss.md
+++ b/docs/worldboss.md
@@ -36,6 +36,10 @@ Fields:
 - `game_currency` and `xp` — reward amounts
 - `item_id` and `sidekick_item_id` — rewarded items
 - `rewards` — serialized additional rewards
+- `claimed` — 1 if the player has claimed the reward
+
+`worldboss_reward` has a unique index on `(worldboss_event_id, character_id)` to
+ensure each player receives at most one reward per event.
 
 ### Activating an event
 
@@ -78,3 +82,14 @@ WHERE status = 1
 
 If the query returns a row, that event is active and should be loaded for
 characters whose `worldboss_event_id` matches the row's `id`.
+
+### Claiming rewards
+
+After an event ends, players can claim their rewards using the
+`claimWorldbossEventRewards` request. The request takes no parameters.
+It grants the coin, XP and item rewards stored in `worldboss_reward` and
+marks the record as claimed.
+
+Response fields:
+- `character` – updated character data
+- `worldboss_reward` – the reward record after claiming

--- a/docs/worldboss.md
+++ b/docs/worldboss.md
@@ -1,0 +1,80 @@
+# Worldboss Tables
+
+This project defines several tables used for global boss events.
+
+## `worldboss_event`
+Fields:
+- `id` — primary key
+- `identifier` — internal name of the event
+- `npc_identifier` — NPC identifier
+- `status` — current state
+- `ts_start` and `ts_end` — event timings
+- `npc_hitpoints_total` and `npc_hitpoints_current`
+- `min_level` and `max_level` — allowed character level range
+- `stage` — progression stage
+- `attack_count` — number of completed attacks
+- `top_attacker_character_id`, `top_attacker_count`, `top_attacker_name`
+- `winning_attacker_name`
+- `ranking`, `coin_reward_total`, `coin_reward_next_attack`
+- `xp_reward_total`, `xp_reward_next_attack`
+- `reward_top_rank_item_identifier`, `reward_top_pool_item_identifier`
+
+## `worldboss_attack`
+Fields:
+- `id` — primary key
+- `worldboss_event_id` — references `worldboss_event`
+- `character_id` — attacking character
+- `battle_id` — ID of the related battle
+- `damage` — damage dealt
+- `ts_start` and `ts_complete`
+- `status` — 1 active, 2 finished
+
+## `worldboss_reward`
+Fields:
+- `id` — primary key
+- `worldboss_event_id` and `character_id` — associated event and player
+- `game_currency` and `xp` — reward amounts
+- `item_id` and `sidekick_item_id` — rewarded items
+- `rewards` — serialized additional rewards
+
+### Activating an event
+
+An admin helper is available at `admin/worldboss.php`. Set `admin_secret` in
+`server/config.php` and provide it in the form along with event data. The script
+creates a new `worldboss_event` record and assigns it to all characters.
+
+### Example event
+
+You can manually insert a small test event with SQL:
+
+```sql
+INSERT INTO worldboss_event
+(identifier, npc_identifier, status, ts_start, ts_end,
+ npc_hitpoints_total, npc_hitpoints_current, min_level, max_level, stage)
+VALUES (
+  'testboss01',
+  'npc_mastermind',
+  1,
+  UNIX_TIMESTAMP(),
+  UNIX_TIMESTAMP() + 86400,
+  500000,
+  500000,
+  1,
+  100,
+  1
+);
+```
+
+### Checking event status
+
+To confirm an event is running, query the table:
+
+```sql
+SELECT * FROM worldboss_event
+WHERE status = 1
+  AND ts_start <= UNIX_TIMESTAMP()
+  AND ts_end > UNIX_TIMESTAMP();
+```
+
+If the query returns a row, that event is active and should be loaded for
+characters whose `worldboss_event_id` matches the row's `id`.

--- a/server/config.php
+++ b/server/config.php
@@ -53,6 +53,7 @@ return [
         "server"=>[
             'flash_ver'=>       'flash_129',
         ],
+        "admin_secret" => "changeme",
         "constants"=>[
             //Init
             "init_game_currency"=>1,

--- a/server/dbschema/WorldbossAttack.php
+++ b/server/dbschema/WorldbossAttack.php
@@ -1,0 +1,24 @@
+<?php
+namespace Schema;
+
+use Srv\Record;
+use JsonSerializable;
+
+class WorldbossAttack extends Record implements JsonSerializable{
+    protected static $_TABLE = 'worldboss_attack';
+
+    public function jsonSerialize(){
+        return $this->getData();
+    }
+
+    protected static $_FIELDS = [
+        'id' => 0,
+        'worldboss_event_id' => 0,
+        'character_id' => 0,
+        'battle_id' => 0,
+        'damage' => 0,
+        'ts_start' => 0,
+        'ts_complete' => 0,
+        'status' => 1
+    ];
+}

--- a/server/dbschema/WorldbossEvent.php
+++ b/server/dbschema/WorldbossEvent.php
@@ -1,0 +1,39 @@
+<?php
+namespace Schema;
+
+use Srv\Record;
+use JsonSerializable;
+
+class WorldbossEvent extends Record implements JsonSerializable{
+    protected static $_TABLE = 'worldboss_event';
+
+    public function jsonSerialize(){
+        return $this->getData();
+    }
+
+    protected static $_FIELDS = [
+        'id' => 0,
+        'identifier' => '',
+        'npc_identifier' => '',
+        'status' => 0,
+        'ts_start' => 0,
+        'ts_end' => 0,
+        'npc_hitpoints_total' => 0,
+        'npc_hitpoints_current' => 0,
+        'min_level' => 1,
+        'max_level' => 1,
+        'stage' => 1,
+        'attack_count' => 0,
+        'top_attacker_character_id' => 0,
+        'top_attacker_count' => 0,
+        'top_attacker_name' => '',
+        'winning_attacker_name' => '',
+        'ranking' => 0,
+        'coin_reward_total' => 0,
+        'coin_reward_next_attack' => 0,
+        'xp_reward_total' => 0,
+        'xp_reward_next_attack' => 0,
+        'reward_top_rank_item_identifier' => '',
+        'reward_top_pool_item_identifier' => ''
+    ];
+}

--- a/server/dbschema/WorldbossReward.php
+++ b/server/dbschema/WorldbossReward.php
@@ -19,7 +19,8 @@ class WorldbossReward extends Record implements JsonSerializable {
         'xp' => 0,
         'item_id' => 0,
         'sidekick_item_id' => 0,
-        'rewards' => ''
+        'rewards' => '',
+        'claimed' => 0
     ];
 }
 

--- a/server/dbschema/WorldbossReward.php
+++ b/server/dbschema/WorldbossReward.php
@@ -1,0 +1,25 @@
+<?php
+namespace Schema;
+
+use Srv\Record;
+use JsonSerializable;
+
+class WorldbossReward extends Record implements JsonSerializable {
+    protected static $_TABLE = 'worldboss_reward';
+
+    public function jsonSerialize() {
+        return $this->getData();
+    }
+
+    protected static $_FIELDS = [
+        'id' => 0,
+        'worldboss_event_id' => 0,
+        'character_id' => 0,
+        'game_currency' => 0,
+        'xp' => 0,
+        'item_id' => 0,
+        'sidekick_item_id' => 0,
+        'rewards' => ''
+    ];
+}
+

--- a/server/request/assignWorldbossEvent.req.php
+++ b/server/request/assignWorldbossEvent.req.php
@@ -1,0 +1,21 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossEvent;
+
+class assignWorldbossEvent{
+    public function __request($player){
+        $event_id = intval(getField('worldboss_event_id', FIELD_NUM));
+        $event = WorldbossEvent::find(function($q) use ($event_id){
+            $q->where('id',$event_id);
+        });
+        if(!$event)
+            return Core::setError('errWorldbossInvalidEvent');
+        $player->character->worldboss_event_id = $event->id;
+        Core::req()->data = [
+            'character'=>$player->character,
+            'worldboss_event'=>$event
+        ];
+    }
+}

--- a/server/request/claimWorldbossEventRewards.req.php
+++ b/server/request/claimWorldbossEventRewards.req.php
@@ -1,0 +1,33 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossReward;
+
+class claimWorldbossEventRewards{
+    public function __request($player){
+        if(!$player->character->worldboss_event_id)
+            return Core::setError('errNoWorldbossEvent');
+
+        $reward = WorldbossReward::find(function($q) use ($player){
+            $q->where('worldboss_event_id', $player->character->worldboss_event_id);
+            $q->where('character_id', $player->character->id);
+        });
+        if(!$reward)
+            return Core::setError('errWorldbossRewardMissing');
+        if($reward->claimed)
+            return Core::setError('errWorldbossRewardAlreadyClaimed');
+
+        $player->giveMoney($reward->game_currency);
+        $player->giveExp($reward->xp);
+        if($reward->rewards)
+            $player->giveRewards($reward->rewards);
+        $reward->claimed = 1;
+        $reward->save();
+
+        Core::req()->data = [
+            'character' => $player->character,
+            'worldboss_reward' => $reward
+        ];
+    }
+}

--- a/server/request/finishWorldbossAttack.req.php
+++ b/server/request/finishWorldbossAttack.req.php
@@ -1,0 +1,38 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossAttack;
+use Schema\WorldbossEvent;
+
+class finishWorldbossAttack{
+    public function __request($player){
+        $attack = WorldbossAttack::find(function($q) use ($player){
+            $q->where('id',$player->character->active_worldboss_attack_id);
+        });
+        if(!$attack)
+            return Core::setError('errNoActiveWorldbossAttack');
+
+        $damage = intval(getField('damage', FIELD_NUM));
+        $attack->damage = $damage;
+        $attack->ts_complete = time();
+        $attack->status = 2;
+
+        $event = WorldbossEvent::find(function($q) use ($attack){
+            $q->where('id',$attack->worldboss_event_id);
+        });
+        if($event){
+            $event->npc_hitpoints_current = max(0,$event->npc_hitpoints_current - $damage);
+            $event->attack_count += 1;
+        }
+
+        $player->character->active_worldboss_attack_id = 0;
+        $player->character->worldboss_event_attack_count += 1;
+
+        Core::req()->data = [
+            'character'=>$player->character,
+            'worldboss_attack'=>$attack,
+            'worldboss_event'=>$event
+        ];
+    }
+}

--- a/server/request/finishWorldbossAttack.req.php
+++ b/server/request/finishWorldbossAttack.req.php
@@ -24,10 +24,12 @@ class finishWorldbossAttack{
         if($event){
             $event->npc_hitpoints_current = max(0,$event->npc_hitpoints_current - $damage);
             $event->attack_count += 1;
+            $event->save();
         }
 
         $player->character->active_worldboss_attack_id = 0;
         $player->character->worldboss_event_attack_count += 1;
+        $attack->save();
 
         Core::req()->data = [
             'character'=>$player->character,

--- a/server/request/getWorldbossReward.req.php
+++ b/server/request/getWorldbossReward.req.php
@@ -1,0 +1,26 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossReward;
+
+class getWorldbossReward{
+    public function __request($player){
+        if(!$player->character->worldboss_event_id)
+            return Core::setError('errNoWorldbossEvent');
+        $reward = WorldbossReward::find(function($q) use ($player){
+            $q->where('worldboss_event_id',$player->character->worldboss_event_id);
+            $q->where('character_id',$player->character->id);
+        });
+        if(!$reward){
+            $reward = new WorldbossReward([
+                'worldboss_event_id'=>$player->character->worldboss_event_id,
+                'character_id'=>$player->character->id
+            ]);
+            $reward->save();
+        }
+        Core::req()->data = [
+            'worldboss_reward'=>$reward
+        ];
+    }
+}

--- a/server/request/loginUser.req.php
+++ b/server/request/loginUser.req.php
@@ -30,6 +30,19 @@ class loginUser{
         $player->user->login_count++;
         
         $dailyLogin = $player->getDailyBonuses();
+        $eventData = [];
+        $rewardData = null;
+        if($player->character->worldboss_event_id){
+            $event = \Schema\WorldbossEvent::find(function($q) use ($player){
+                $q->where('id',$player->character->worldboss_event_id);
+            });
+            if($event)
+                $eventData = $event;
+            $rewardData = \Schema\WorldbossReward::find(function($q) use ($player){
+                $q->where('worldboss_event_id',$player->character->worldboss_event_id);
+                $q->where('character_id',$player->character->id);
+            });
+        }
 
         Core::req()->data = array(
             "user"=>$player->user,
@@ -68,7 +81,8 @@ class loginUser{
 			"ad_provider_keys"=>array(),
             "tournament_end_timestamp"=>0,
             "user_geo_location"=>"xX",
-            "worldboss_event_character_data"=>array()
+            "worldboss_event_character_data"=>$eventData,
+            "worldboss_reward_data"=>$rewardData
         );
         if($player->guild != null){
         	Core::req()->data['guild']= $player->guild;

--- a/server/request/startWorldbossAttack.req.php
+++ b/server/request/startWorldbossAttack.req.php
@@ -1,0 +1,35 @@
+<?php
+namespace Request;
+
+use Srv\Core;
+use Schema\WorldbossEvent;
+use Schema\WorldbossAttack;
+
+class startWorldbossAttack{
+    public function __request($player){
+        if($player->character->active_worldboss_attack_id)
+            return Core::setError('errWorldbossAttackActive');
+        if(!$player->character->worldboss_event_id)
+            return Core::setError('errNoWorldbossEvent');
+
+        $event = WorldbossEvent::find(function($q) use ($player){
+            $q->where('id',$player->character->worldboss_event_id);
+        });
+        if(!$event || $event->status != 1)
+            return Core::setError('errWorldbossInvalidEvent');
+
+        $attack = new WorldbossAttack([
+            'worldboss_event_id'=>$event->id,
+            'character_id'=>$player->character->id,
+            'ts_start'=>time(),
+            'status'=>1
+        ]);
+        $attack->save();
+        $player->character->active_worldboss_attack_id = $attack->id;
+
+        Core::req()->data = [
+            'character'=>$player->character,
+            'worldboss_attack'=>$attack
+        ];
+    }
+}

--- a/server/request/startWorldbossAttack.req.php
+++ b/server/request/startWorldbossAttack.req.php
@@ -18,6 +18,10 @@ class startWorldbossAttack{
         if(!$event || $event->status != 1)
             return Core::setError('errWorldbossInvalidEvent');
 
+        $now = time();
+        if($now < $event->ts_start || $now >= $event->ts_end)
+            return Core::setError('errWorldbossInvalidEvent');
+
         $attack = new WorldbossAttack([
             'worldboss_event_id'=>$event->id,
             'character_id'=>$player->character->id,


### PR DESCRIPTION
## Summary
- add sample SQL to create a worldboss event
- document how to check if an event is active

## Testing
- `php -l admin/worldboss.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409039656883299917b02da7e68b53